### PR TITLE
Modify winmd2md formatting style for WebView2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The output is saved to the `out` folder under the current folder.
    /fieldsAsTable         Output Fields as a table
    /? or /help            Display help
    /sdkVersion            SDK version number to use (e.g. 10.0.18362.0)
-   /fileSuffix            File suffix to append to each generated markdown file. Default is "-api-windows"
+   /fileSuffix            File suffix to append to each generated markdown file. Default is empty string
    /outputDirectory       Directory where output will be written. Default is "out"
    /printReferenceGraph   Displays the list of types that reference each type
 ```

--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -183,7 +183,7 @@ string Formatter::ToString(const coded_index<TypeDefOrRef>& tdr, bool toCode) {
       const auto& ac = s.GenericArgCount();
       const auto& outerType = std::string(ToString(p, false));
       const auto& prettyOuterType = outerType.substr(1, outerType.find('`') - 1);
-      string result = typeToMarkdown(p.TypeRef().TypeNamespace(), prettyOuterType, false, "-" + std::to_string(ac)) + "<";
+      string result = typeToMarkdown(p.TypeRef().TypeNamespace(), prettyOuterType, false, "-" + std::to_string(ac)) + "&lt;";
 
       bool first = true;
       for (auto const& a : s.GenericArgs())
@@ -195,7 +195,7 @@ string Formatter::ToString(const coded_index<TypeDefOrRef>& tdr, bool toCode) {
         result += x;
         first = false;
       }
-      result += ">";
+      result += "&gt;";
       return result;
     }
     default:
@@ -228,7 +228,7 @@ string Formatter::GetType(const TypeSig::value_type& valueType)
     const auto& outerType = std::string(ToString(genericType, false));
     stringstream ss;
     const auto& prettyOuterType = outerType.substr(1, outerType.find('`') - 1);
-    ss << typeToMarkdown(genericType.TypeRef().TypeNamespace(), prettyOuterType, true, "-" + std::to_string(gt.GenericArgCount())) << '<';
+    ss << typeToMarkdown(genericType.TypeRef().TypeNamespace(), prettyOuterType, true, "-" + std::to_string(gt.GenericArgCount())) << "&lt;";
 
     bool first = true;
 
@@ -245,7 +245,7 @@ string Formatter::GetType(const TypeSig::value_type& valueType)
       // This indicates that we relied on a temporary that got deleted when chaining several calls
       throw std::invalid_argument("you found a bug - we probably deleted an object we shouldn't (when doing a.b().c().d())");
     }
-    ss << '>';
+    ss << "&gt;";
     return ss.str();
   }
   case 4: // GenericMethodTypeIndex

--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -14,7 +14,7 @@ string Formatter::MakeMarkdownReference(const string& ns, const string& type, co
   string link = type;
   std::transform(link.begin(), link.end(), link.begin(), ::tolower);
   if (ns != program->currentNamespace && !ns.empty()) {
-    return typeToMarkdown(ns, type + (!propertyName.empty() ? ("." + propertyName) : ""), true);
+    return typeToMarkdown(ns, type + (!propertyName.empty() ? ("." + propertyName) : ""), false);
   }
   link += link.empty() ? "" : ".md";
   if (!propertyName.empty()) {
@@ -33,10 +33,10 @@ string Formatter::MakeMarkdownReference(const string& ns, const string& type, co
     if (dot != -1) {
       auto ns = type.substr(0, dot);
       auto typeName = type.substr(dot + 1);
-      return typeToMarkdown(ns, typeName, true);
+      return typeToMarkdown(ns, typeName, false);
     }
   }
-  return "[" + code(anchor) + "](" + link + ")";
+  return "[" + anchor + "](" + link + ")";
 }
 
 string Formatter::MakeXmlReference(const string& ns, const string& type, const string& propertyName) {
@@ -127,7 +127,9 @@ std::string Formatter::typeToMarkdown(std::string_view ns, std::string type, boo
   string code = toCode ? "`" : "";
   if (ns.empty()) return type; // basic type
   else if (ns == program->currentNamespace) {
-    return "[" + code + type + code + "](" + type + ")";
+    string link = type;
+    std::transform(link.begin(), link.end(), link.begin(), ::tolower);
+    return "[" + code + type + code + "](" + link + ".md)";
   }
   else {
     for (const auto& ns_prefix : docs_msft_com_namespaces) {

--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -12,9 +12,11 @@ using namespace winmd::reader;
 string Formatter::MakeMarkdownReference(const string& ns, const string& type, const string& propertyName) {
   string anchor = type;
   string link = type;
+  std::transform(link.begin(), link.end(), link.begin(), ::tolower);
   if (ns != program->currentNamespace && !ns.empty()) {
     return typeToMarkdown(ns, type + (!propertyName.empty() ? ("." + propertyName) : ""), true);
   }
+  link += link.empty() ? "" : ".md";
   if (!propertyName.empty()) {
     anchor += (!type.empty() ? "." : "") + propertyName;
     auto p = propertyName;
@@ -48,7 +50,9 @@ std::string code(std::string_view v) {
 
 string link(string_view n) {
   //if (IsBuiltInType(n)) return string(n);
-  return "- [" + code(n) + "](" + string(n) + ")";
+  string link = string(n);
+  std::transform(link.begin(), link.end(), link.begin(), ::tolower);
+  return "- [" + string(n) + "](" + link + ".md)";
 }
 
 bool isIdentifierChar(char x) {
@@ -130,7 +134,8 @@ std::string Formatter::typeToMarkdown(std::string_view ns, std::string type, boo
       if (ns._Starts_with(ns_prefix)) {
         // if it is a Windows type use MSDN, e.g.
         // https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Automation.ExpandCollapseState
-        const std::string docsURL = "https://docs.microsoft.com/uwp/api/";
+        // Use site relative url
+        const std::string docsURL = "/uwp/api/";
         return "[" + code + type + code + "](" + docsURL + string(ns) + "." + type + urlSuffix + ")";
       }
     }

--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -64,8 +64,15 @@ string Formatter::ResolveReferences(string sane, Converter converter) {
   stringstream ss;
 
   for (size_t input = 0; input < sane.length(); input++) {
+    // Reserve $ as a special end-of-reference charater
+    // It's useful when we have something like @TypeName$.NON_PROPERTY_NAME
+    // where NON_PROPERTY_NAME is not an anchor (e.g. @Enum.EnumValue where
+    // there's no anchor for Enumvalues)
+    if (sane[input] == '$') {
+      continue;
+    }
     if (sane[input] == '@') {
-      auto firstNonIdentifier = std::find_if(sane.begin() + input + 1, sane.end(), [](auto& x) { return !isIdentifierChar(x); });
+      auto firstNonIdentifier = std::find_if(sane.begin() + input + 1, sane.end(), [](auto& x) { return !isIdentifierChar(x) || x == '$'; });
       if (firstNonIdentifier != sane.begin() && *(firstNonIdentifier - 1) == '.') {
         firstNonIdentifier--;
       }

--- a/winmd2markdown/Format.cpp
+++ b/winmd2markdown/Format.cpp
@@ -176,7 +176,7 @@ string Formatter::ToString(const coded_index<TypeDefOrRef>& tdr, bool toCode) {
       const auto& ac = s.GenericArgCount();
       const auto& outerType = std::string(ToString(p, false));
       const auto& prettyOuterType = outerType.substr(1, outerType.find('`') - 1);
-      string result = typeToMarkdown(p.TypeRef().TypeNamespace(), prettyOuterType, true, "-" + std::to_string(ac)) + "<";
+      string result = typeToMarkdown(p.TypeRef().TypeNamespace(), prettyOuterType, false, "-" + std::to_string(ac)) + "<";
 
       bool first = true;
       for (auto const& a : s.GenericArgs())

--- a/winmd2markdown/Format.h
+++ b/winmd2markdown/Format.h
@@ -21,7 +21,7 @@ struct Formatter
   std::string GetNamespacePrefix(std::string_view ns);
 
   static std::string_view ToString(winmd::reader::ElementType elementType);
-  std::string ToString(const winmd::reader::coded_index<winmd::reader::TypeDefOrRef>& tdr, bool toCode = true);
+  std::string ToString(const winmd::reader::coded_index<winmd::reader::TypeDefOrRef>& tdr, bool toCode = false);
 
 
   std::string GetType(const winmd::reader::TypeSig& type);

--- a/winmd2markdown/Options.cpp
+++ b/winmd2markdown/Options.cpp
@@ -14,8 +14,9 @@ const std::vector<option>  get_option_names() {
     { "apiVersion", "API version number to use (e.g. 0.64). This is the version that the WinMD corresponds to.", STRING_SWITCH_SETTER(apiVersion) },
     { "fileSuffix", "File suffix to append to each generated markdown file. Default is empty string", STRING_SWITCH_SETTER(fileSuffix) },
     { "outputDirectory", "Directory where output will be written. Default is \"out\"", STRING_SWITCH_SETTER(outputDirectory) },
-    { "printReferenceGraph", "Displays the list of types that reference each type", BOOL_SWITCH_SETTER(printReferenceGraph )},
-    { "strictReferences", "Produce an error when failing to resolve a reference", BOOL_SWITCH_SETTER(strictReferences)},
+    { "printReferenceGraph", "Displays the list of types that reference each type", BOOL_SWITCH_SETTER(printReferenceGraph) },
+    { "strictReferences", "Produce an error when failing to resolve a reference", BOOL_SWITCH_SETTER(strictReferences) },
+    { "msDate", "ms.date to use in header", STRING_SWITCH_SETTER(msDate) },
   };
   return option_names;
 }

--- a/winmd2markdown/Options.cpp
+++ b/winmd2markdown/Options.cpp
@@ -12,7 +12,7 @@ const std::vector<option>  get_option_names() {
     { "help", "Display help", BOOL_SWITCH_SETTER(help) },
     { "sdkVersion", "Windows SDK version number to use (e.g. 10.0.18362.0)", STRING_SWITCH_SETTER(sdkVersion) },
     { "apiVersion", "API version number to use (e.g. 0.64). This is the version that the WinMD corresponds to.", STRING_SWITCH_SETTER(apiVersion) },
-    { "fileSuffix", "File suffix to append to each generated markdown file. Default is \"-api-windows\"", STRING_SWITCH_SETTER(fileSuffix) },
+    { "fileSuffix", "File suffix to append to each generated markdown file. Default is empty string", STRING_SWITCH_SETTER(fileSuffix) },
     { "outputDirectory", "Directory where output will be written. Default is \"out\"", STRING_SWITCH_SETTER(outputDirectory) },
     { "printReferenceGraph", "Displays the list of types that reference each type", BOOL_SWITCH_SETTER(printReferenceGraph )},
     { "strictReferences", "Produce an error when failing to resolve a reference", BOOL_SWITCH_SETTER(strictReferences)},

--- a/winmd2markdown/Options.h
+++ b/winmd2markdown/Options.h
@@ -26,6 +26,7 @@ struct options
   bool printReferenceGraph{ false };
   std::string apiVersion;
   bool strictReferences{ false };
+  std::string msDate{ "<!--DATE-->" };
 
   options(const std::vector<std::string>& v) {
     auto const opts = get_option_names();

--- a/winmd2markdown/Options.h
+++ b/winmd2markdown/Options.h
@@ -21,7 +21,7 @@ struct options
   bool help{ false };
   std::string sdkVersion;
   std::string winMDPath;
-  std::string fileSuffix{ "-api-windows" };
+  std::string fileSuffix{ "" };
   std::string outputDirectory{ "out" };
   bool printReferenceGraph{ false };
   std::string apiVersion;

--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -746,7 +746,7 @@ description: Explore all classes and interfaces of the Microsoft.Web.WebView2.Co
 title: Microsoft.Web.WebView2.Core Namespace
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: <!--DATE-->
+ms.date: )" << opts->msDate << R"(
 ms.topic: reference
 ms.prod: microsoft-edge
 ms.technology: webview

--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -121,7 +121,7 @@ bool Program::shouldSkipInterface(const IT /*TypeDef*/& interfaceEntry) {
 /// <param name="ss"></param>
 /// <param name="type"></param>
 /// <param name="fallback_type"></param>
-template<typename T, typename F = nullptr_t>
+template<typename T, typename F/* = nullptr_t*/>
 void Program::PrintOptionalSections(MemberType mt, output& ss, const T& type, std::optional<F> fallback_type)
 {
   if (IsExperimental(type)) {

--- a/winmd2markdown/Program.cpp
+++ b/winmd2markdown/Program.cpp
@@ -690,10 +690,17 @@ void Program::write_index(string_view namespaceName, const cache::namespace_memb
 
   const auto apiVersionPrefix = (opts->apiVersion != "") ? ("version-" + opts->apiVersion + "-") : "";
 
+  // Adding ms metadata
   index << R"(---
-id: )" << apiVersionPrefix << R"(Native-API-Reference
-title: namespace )" << namespaceName << R"(
-sidebar_label: Full reference
+description: Explore all classes and interfaces of the Microsoft.Web.WebView2.Core namespace.
+title: Microsoft.Web.WebView2.Core Namespace
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.date: <!--DATE-->
+ms.topic: reference
+ms.prod: microsoft-edge
+ms.technology: webview
+keywords: IWebView2, IWebView2WebView, webview2, webview, winrt, Microsoft.Web.WebView2.Core, edge, ICoreWebView2, ICoreWebView2Controller, ICoreWebView2Interop, browser control, edge html
 )";
 
   if (opts->apiVersion != "") {
@@ -703,35 +710,36 @@ sidebar_label: Full reference
   index << R"(
 ---
 
+# Microsoft.Web.WebView2.Core Namespace
 )";
 
-  index << "## Enums" << "\n";
-  for (auto const& t : ns.enums) {
-    if (!opts->outputExperimental && IsExperimental(t)) continue;
-    index << link(t.TypeName()) << "\n";
-  }
-
-  index << "## Interfaces" << "\n";
-  for (auto const& t : ns.interfaces) {
-    if (!opts->outputExperimental && IsExperimental(t)) continue;
-    if (shouldSkipInterface(t)) continue;
-    index << link(t.TypeName()) << "\n";
-  }
-
-  index << "## Structs" << "\n";
-  for (auto const& t : ns.structs) {
-    if (!opts->outputExperimental && IsExperimental(t)) continue;
-    index << link(t.TypeName()) << "\n";
-  }
-
-  index << "## Classes" << "\n";
+  index << "\n## Classes\n\n";
 
   for (auto const& t : ns.classes) {
     if (!opts->outputExperimental && IsExperimental(t)) continue;
     index << link(t.TypeName()) << "\n";
   }
 
-  index << "## Delegates" << "\n";
+  index << "\n## Interfaces\n\n";
+  for (auto const& t : ns.interfaces) {
+    if (!opts->outputExperimental && IsExperimental(t)) continue;
+    if (shouldSkipInterface(t)) continue;
+    index << link(t.TypeName()) << "\n";
+  }
+
+  index << "\n## Enums\n\n";
+  for (auto const& t : ns.enums) {
+    if (!opts->outputExperimental && IsExperimental(t)) continue;
+    index << link(t.TypeName()) << "\n";
+  }
+
+  index << "\n## Structs\n\n";
+  for (auto const& t : ns.structs) {
+    if (!opts->outputExperimental && IsExperimental(t)) continue;
+    index << link(t.TypeName()) << "\n";
+  }
+
+  index << "\n## Delegates\n\n";
   for (auto const& t : ns.delegates) {
     if (!opts->outputExperimental && IsExperimental(t)) continue;
     index << link(t.TypeName()) << "\n";

--- a/winmd2markdown/Program.h
+++ b/winmd2markdown/Program.h
@@ -31,8 +31,9 @@ struct Program {
 private:
   void process_class(output& ss, const winmd::reader::TypeDef& type, std::string kind);
   void process_enum(output& ss, const winmd::reader::TypeDef& type);
-  void process_property(output& ss, const winmd::reader::Property& prop);
-  void process_method(output& ss, const winmd::reader::MethodDef& method, std::string_view realName = "");
+  void process_event(output& ss, const winmd::reader::TypeDef& classType, const winmd::reader::Event& evt, bool asTable = false);
+  void process_property(output& ss, const winmd::reader::Property& prop, bool asTable = false);
+  void process_method(output& ss, const winmd::reader::MethodDef& method, std::string_view realName = "", bool asTable = false);
   void process_field(output& ss, const winmd::reader::Field& field);
   void process_struct(output& ss, const winmd::reader::TypeDef& type);
   void process_delegate(output& ss, const winmd::reader::TypeDef& type);

--- a/winmd2markdown/output.cpp
+++ b/winmd2markdown/output.cpp
@@ -34,7 +34,7 @@ output::type_helper output::StartType(std::string_view name, std::string_view ki
     "title: " << name << R"(
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: <!--DATE-->
+ms.date: )" << program->opts->msDate << R"(
 ms.topic: reference
 ms.prod: microsoft-edge
 ms.technology: webview

--- a/winmd2markdown/output.cpp
+++ b/winmd2markdown/output.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 #include "Options.h"
 
@@ -15,7 +16,7 @@ output::output(Program* p) : program(p) {
 
 filesystem::path output::GetFileForType(std::string_view name) {
   std::filesystem::path out(program->opts->outputDirectory);
-  const string filename = std::string(name) + program->opts->fileSuffix + ".md";
+  const string filename = boost::algorithm::to_lower_copy(std::string(name)) + program->opts->fileSuffix + ".md";
   if (!std::filesystem::exists(out)) {
     std::error_code ec;
     std::filesystem::create_directory(out, ec); // ignore ec

--- a/winmd2markdown/output.cpp
+++ b/winmd2markdown/output.cpp
@@ -28,9 +28,17 @@ output::type_helper output::StartType(std::string_view name, std::string_view ki
   indents = 0;
   currentFile = std::move(GetOutputStream(GetFileForType(name)));
   const auto apiVersionPrefix = (program->opts->apiVersion != "") ? ("version-" + program->opts->apiVersion + "-") : "";
+  // Adding ms metadata
   *currentFile << "---\n" <<
-    "id: " << apiVersionPrefix << name << "\n" <<
-    "title: " << name << "\n";
+    "title: " << name << R"(
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.date: <!--DATE-->
+ms.topic: reference
+ms.prod: microsoft-edge
+ms.technology: webview
+keywords: webview2, webview, winrt, win32, edge, CoreWebView2, CoreWebView2Controller, browser control, edge html, )" <<
+    name << "\n";
 
   if (program->opts->apiVersion != "") {
     *currentFile << "original_id: " << name << "\n";

--- a/winmd2markdown/output.cpp
+++ b/winmd2markdown/output.cpp
@@ -45,8 +45,13 @@ keywords: webview2, webview, winrt, win32, edge, CoreWebView2, CoreWebView2Contr
   }
 
   *currentFile << "---\n\n";
-  *currentFile << "Kind: " << code(kind) << "\n\n";
-  return type_helper(*this);
+  string header = string{ name };
+  if (kind == "class") {
+    header = "runtimeClass " + header;
+  } else {
+    header = string(kind) + " " + header;
+  }
+  return type_helper(*this, header);
 }
 
 output::section_helper output::StartSection(const std::string& a) {
@@ -61,7 +66,7 @@ output::section_helper::section_helper(output& out, string s) : o(out) {
   }
 }
 
-output::type_helper::type_helper(output& out) : o(out), sh(o.StartSection("")) {};
+output::type_helper::type_helper(output& out, std::string kind) : o(out), sh(o.StartSection(kind + "\n")) {};
 
 void output::StartNamespace(std::string_view namespaceName) {
   currentXml = intellisense_xml(namespaceName);

--- a/winmd2markdown/output.h
+++ b/winmd2markdown/output.h
@@ -106,7 +106,7 @@ private:
   struct type_helper {
     output& o;
     section_helper sh;
-    type_helper(output& out);
+    type_helper(output& out, std::string kind);
     ~type_helper() {
       o.EndType();
     }


### PR DESCRIPTION
Modified format/styles of winmd2md for WebView2 WinRT reference content.

- Default `toCode` to false
- Generate ms metadata headings per file
- Change `/fileSuffix` to default to an empty string; use lowercased filenames
- Add `/msDate` option to specify `ms.date` used in the headings; default is `<!--DATE-->`
- Generate a Summary section right above all Members sections (Properties, Methods, and Events)
- Use site-relative URLs (remove prepended `https://docs.microsoft.com`) for Windows APIs
- Reserve '$' as an end-of-reference character